### PR TITLE
创建了后台管理的初始页面:导航栏,病例管理的初始页面等(菜单导航跳转还未配好)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/

--- a/.idea/PetHospital.iml
+++ b/.idea/PetHospital.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/PetHospital.iml" filepath="$PROJECT_DIR$/.idea/PetHospital.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Exam from './pages_front/exam/exam.tsx';
 import NavBar from "./Components/Navbar.tsx";
 import UserInfo from "./pages_back/userInfo/userInfo.tsx";
 import Footer from "./Components/footer.tsx";
+import SystemMenu from "./pages_back/systemMenu/systemMenu.tsx";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import "./style.css";
 import "./App.css";
@@ -23,6 +24,7 @@ function App() {
 				<Route path='/exam' element={<Exam />} />
 				<Route path='/userinfo' element={<UserInfo />} />
 				<Route path='/detail' element={<Detail />} />
+				<Route path='/systemMenu' element={<SystemMenu />} />
 			</Routes>
 			</div>
 			<Footer />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -35,7 +35,7 @@ function NavBar() {
 
             <NavDropdown title="User">
               <NavDropdown.Item href="/userinfo">Information</NavDropdown.Item>
-              <NavDropdown.Item href="/">Management System</NavDropdown.Item>
+              <NavDropdown.Item href="/systemMenu">Management System</NavDropdown.Item>
               <NavDropdown.Item href="/">Log Out</NavDropdown.Item>
             </NavDropdown>
           </Nav>

--- a/src/pages_back/examManage/examManage.tsx
+++ b/src/pages_back/examManage/examManage.tsx
@@ -1,8 +1,0 @@
-import React from 'react'
-
-const ExamManage = () => {
-  return(
-    <h1>Userinfo</h1>
-  )
-}
-export default ExamManage;

--- a/src/pages_back/router/index.tsx
+++ b/src/pages_back/router/index.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+//Navigate重定向组件
+import { Navigate } from "react-router-dom"
+
+import Home from "../../pages_front/home/home"
+import UserInfo from "../userInfo/userInfo"
+
+// const CaseManage = lazy(() => import("../caseManage/caseManage"))
+
+// const withLoadingComponent = (comp:JSX.Element) => (
+//     <React.Suspense fallback = {<div>Loading...</div>}>
+//         {comp}
+//     </React.Suspense>
+// )
+
+// 配置导航栏的嵌套路由
+const routes = [
+    {
+        path: "/",
+        // 默认进来的第一个页面
+        element: <Navigate to="/systemMenu" />
+
+    },
+    {
+        path: "/",
+        element: <Home />,
+        children: [
+            {
+                path: "/userInfo",
+                element: <UserInfo />
+            }
+        ]
+    },
+]
+
+export default routes

--- a/src/pages_back/systemMenu/caseManage/caseData.tsx
+++ b/src/pages_back/systemMenu/caseManage/caseData.tsx
@@ -1,0 +1,18 @@
+import { CaseType } from "./caseType";
+
+//这里存储的是病例相关的数据
+export const caseData: CaseType[] = [
+    {
+      key: '1',
+      case_id: 1,
+      case_name: '寄生虫病1',
+      disease_name: '寄生虫病',
+    },
+    {
+      key: '2',
+      case_id: 2,
+      case_name: '寄生虫病2',
+      disease_name: '寄生虫病',
+    },
+  ];
+

--- a/src/pages_back/systemMenu/caseManage/caseType.tsx
+++ b/src/pages_back/systemMenu/caseManage/caseType.tsx
@@ -1,0 +1,8 @@
+//这里定义病例数据属性
+export type CaseType = {
+    key: string;
+    case_id: number;
+    case_name: string;
+    disease_name: string;
+  }
+  

--- a/src/pages_back/systemMenu/caseManage/caseUpload.tsx
+++ b/src/pages_back/systemMenu/caseManage/caseUpload.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { PlusOutlined } from '@ant-design/icons';
+import { Modal, Upload } from 'antd';
+import type { RcFile, UploadProps } from 'antd/es/upload';
+import type { UploadFile } from 'antd/es/upload/interface';
+import { UploadOutlined, } from '@ant-design/icons';
+
+//上传病例
+
+const getBase64 = (file: RcFile): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+  });
+
+
+const App: React.FC = () => {
+    const [previewOpen, setPreviewOpen] = useState(false);
+    const [previewImage, setPreviewImage] = useState('');
+    const [previewTitle, setPreviewTitle] = useState('');
+    const [fileList, setFileList] = useState<UploadFile[]>([
+      {
+        uid: '-1',
+        name: 'image.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+      },
+      {
+        uid: '-2',
+        name: 'image.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+      },
+      {
+        uid: '-3',
+        name: 'image.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+      },
+      {
+        uid: '-4',
+        name: 'image.png',
+        status: 'done',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+      },
+      {
+        uid: '-xxx',
+        percent: 50,
+        name: 'image.png',
+        status: 'uploading',
+        url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+      },
+      {
+        uid: '-5',
+        name: 'image.png',
+        status: 'error',
+      },
+    ]);
+  
+    const handleCancel = () => setPreviewOpen(false);
+  
+    const handlePreview = async (file: UploadFile) => {
+      if (!file.url && !file.preview) {
+        file.preview = await getBase64(file.originFileObj as RcFile);
+      }
+  
+      setPreviewImage(file.url || (file.preview as string));
+      setPreviewOpen(true);
+      setPreviewTitle(file.name || file.url!.substring(file.url!.lastIndexOf('/') + 1));
+    };
+  
+    const handleChange: UploadProps['onChange'] = ({ fileList: newFileList }) =>
+      setFileList(newFileList);
+  
+    const uploadButton = (
+      <div>
+        <PlusOutlined />
+        <div style={{ marginTop: 8 }}>Upload</div>
+      </div>
+    );
+    return (
+      <>
+        <Upload
+          action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+          listType="picture-card"
+          fileList={fileList}
+          onPreview={handlePreview}
+          onChange={handleChange}
+        >
+          {fileList.length >= 8 ? null : uploadButton}
+        </Upload>
+        <Modal open={previewOpen} title={previewTitle} footer={null} onCancel={handleCancel}>
+          <img alt="example" style={{ width: '100%' }} src={previewImage} />
+        </Modal>
+      </>
+    );
+  };
+  
+  export default App;

--- a/src/pages_back/systemMenu/systemMenu.css
+++ b/src/pages_back/systemMenu/systemMenu.css
@@ -1,0 +1,12 @@
+
+
+.site-layout {
+    background-color: #97abd3;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-size: calc(10px + 2vmin);
+    color: white;
+  }

--- a/src/pages_back/systemMenu/systemMenu.tsx
+++ b/src/pages_back/systemMenu/systemMenu.tsx
@@ -1,0 +1,270 @@
+import React, { useState, useRef } from 'react';
+import {
+  ContainerOutlined,
+  PieChartOutlined,
+  UserOutlined,
+  AppstoreAddOutlined,
+  HddOutlined,
+  ContactsOutlined,
+  MedicineBoxOutlined,
+  FileTextOutlined,
+  ReconciliationOutlined,
+  FolderOpenOutlined,
+  IdcardOutlined,
+  TeamOutlined,
+  PartitionOutlined,
+  UploadOutlined,
+
+} from '@ant-design/icons';
+import type { ColumnsType, ColumnType } from 'antd/es/table';
+import { DeleteTwoTone, SearchOutlined, EditTwoTone } from '@ant-design/icons';
+import { MenuProps, Button, Input, Space, Table, Upload } from 'antd'
+import { Layout, InputRef, Menu, theme } from 'antd';
+import type { FilterConfirmProps } from 'antd/es/table/interface';
+import Highlighter from 'react-highlight-words';
+//导入caseData & CaseType
+import { caseData } from './caseManage/caseData.tsx';
+import { CaseType } from "./caseManage/caseType";
+//重定向路由
+import { useRoutes, Outlet, useNavigate } from "react-router-dom";
+import "./systemMenu.css";
+
+
+const { Content, Sider } = Layout;
+
+//列的下标
+type DataIndex = keyof CaseType;
+
+//菜单Item
+type MenuItem = Required<MenuProps>['items'][number];
+
+function getItem(
+  label: React.ReactNode,
+  key: React.Key,
+  icon?: React.ReactNode,
+  children?: MenuItem[],
+  type?: 'group',
+): MenuItem {
+  return {
+    key,
+    icon,
+    children,
+    label,
+    type,
+  } as MenuItem;
+}
+
+const items: MenuItem[] = [
+  // item: label key（写路径） icon children type
+  getItem('病例管理', '/systemMenu', <AppstoreAddOutlined />),
+  getItem('病种管理', '2', <ContainerOutlined />),
+  getItem('用户管理', '/userInfo', <UserOutlined />),
+  getItem('考试管理', '/examManage', <ReconciliationOutlined />, [
+    getItem('考题管理', '4', <FolderOpenOutlined />),
+    getItem('试卷管理', '5', <FileTextOutlined />),
+  ]),
+
+  getItem('医院管理', 'sub2', <PieChartOutlined />, [
+    getItem('科室管理', '6', <ContactsOutlined />),
+    getItem('药品管理', '7', <HddOutlined />),
+    getItem('疫苗管理', '8', <MedicineBoxOutlined />),
+  ]),
+
+  getItem('职能学习管理', 'sub3', <IdcardOutlined />, [
+    getItem('岗位角色管理', '9', <TeamOutlined />),
+    getItem('流程管理', '10', <PartitionOutlined />),
+  ])
+];
+
+
+
+
+const SystemMenu: React.FC = () => {
+  const [collapsed, setCollapsed] = useState(false);
+  const navigateTo = useNavigate(); //定义一个跳转遍历
+
+
+  const [searchText, setSearchText] = useState('');
+  const [searchedColumn, setSearchedColumn] = useState('');
+  // 搜索输入框
+  const searchInput = useRef<InputRef>(null);
+
+  //处理搜索的函数
+  const handleSearch = (
+    selectedKeys: string[],
+    confirm: (param?: FilterConfirmProps) => void,
+    dataIndex: DataIndex,
+  ) => {
+    confirm();
+    setSearchText(selectedKeys[0]);
+    setSearchedColumn(dataIndex);
+  };
+
+  //重置
+  const handleReset = (clearFilters: () => void) => {
+    clearFilters();
+    setSearchText('');
+  };
+
+  //获取列
+  const getColumnSearchProps = (dataIndex: DataIndex): ColumnType<CaseType> => ({
+    filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters, close }) => (
+      <div style={{ padding: 8 }} onKeyDown={(e) => e.stopPropagation()}>
+        <Input
+          ref={searchInput}
+          placeholder={`Search ${dataIndex}`}
+          value={selectedKeys[0]}
+          onChange={(e) => setSelectedKeys(e.target.value ? [e.target.value] : [])}
+          onPressEnter={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
+          style={{ marginBottom: 8, display: 'block' }}
+        />
+        <Space>
+          <Button
+            type="primary"
+            onClick={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
+            icon={<SearchOutlined />}
+            size="small"
+            style={{ width: 90 }}
+          >
+            Search
+          </Button>
+          <Button
+            onClick={() => clearFilters && handleReset(clearFilters)}
+            size="small"
+            style={{ width: 90 }}
+          >
+            Reset
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            onClick={() => {
+              confirm({ closeDropdown: false });
+              setSearchText((selectedKeys as string[])[0]);
+              setSearchedColumn(dataIndex);
+            }}
+          >
+            Filter
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            onClick={() => {
+              close();
+            }}
+          >
+            close
+          </Button>
+        </Space>
+      </div>
+    ),
+    filterIcon: (filtered: boolean) => (
+      <SearchOutlined style={{ color: filtered ? '#1890ff' : undefined }} />
+    ),
+    onFilter: (value, record) =>
+      record[dataIndex]
+        .toString()
+        .toLowerCase()
+        .includes((value as string).toLowerCase()),
+    onFilterDropdownOpenChange: (visible) => {
+      if (visible) {
+        setTimeout(() => searchInput.current?.select(), 100);
+      }
+    },
+    //渲染搜索框页面
+    render: (text) =>
+      searchedColumn === dataIndex ? (
+        <Highlighter
+          highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
+          searchWords={[searchText]}
+          autoEscape
+          textToHighlight={text ? text.toString() : ''}
+        />
+      ) : (
+        text
+      ),
+  });
+
+  // 定义列
+  const columns: ColumnsType<CaseType> = [
+    {
+      title: '序号',
+      dataIndex: 'key',
+      key: 'key',
+    },
+    {
+      title: '疾病名',
+      dataIndex: 'disease_name',
+      key: 'disease_name',
+      // width: '30%',
+      // 该列添加搜索功能
+      ...getColumnSearchProps('disease_name'),
+      // render: (text) => <a>{text}</a>,
+    },
+    {
+      title: '病例名',
+      dataIndex: 'case_name',
+      key: 'case_name',
+      // width: '50%',
+      ...getColumnSearchProps('case_name'),
+    },
+    {
+      title: '操作',
+      key: 'action',
+      render: (_, record) => (
+        <Space size="middle">
+          <EditTwoTone />
+          <DeleteTwoTone />
+        </Space>
+      ),
+    },
+  ];
+
+
+  // const outlet =  useRoutes(Router);
+  const menuClick: MenuProps['onClick'] = (e) => {
+    console.log('click ', e.key);
+    // 点击跳转到对应的路由 -- 用到hook -- 调用navigateTo?gi
+    navigateTo(e.key);
+  };
+
+  //点击上传病例
+  const upLoadCase = (e) => {
+    console.log('跳转至上传病例页面');
+    navigateTo('/caseManage/caseUpload');
+  }
+
+  return (
+    <Layout style={{ minHeight: '100vh' }}>
+      {/* 左边侧边栏 */}
+      <Sider collapsible collapsed={collapsed} onCollapse={(value) => setCollapsed(value)}>
+        {/* <div className = "logo" style={{ height: 32, margin: 16, background: 'rgba(255, 255, 255, 0.2)' }} /> */}
+        <Menu theme="dark"
+          defaultSelectedKeys={['1']}
+          mode="inline"
+          items={items}
+          onClick={menuClick} />
+      </Sider>
+      {/* 右边的内容 */}
+      {/* TODO 这个背景色如何与主页面一致？ */}
+      <Layout className="site-layout" >
+        {/* <Header style={{ padding: 0, background: colorBgContainer }} /> */}
+        <Content className='site-layout-content'>
+          <div style={{ margin: 16 }}>
+            <Button type="primary" onClick={upLoadCase}>上传病例<UploadOutlined /> </Button>
+          </div>
+          
+          {/* 病例的表格 */}
+          <div className='case_box' style={{ margin: 16 }} >
+            <Table className="case_table" columns={columns} dataSource={caseData} />;
+          </div>
+          <Outlet />
+
+        </Content>
+
+      </Layout>
+    </Layout>
+  );
+};
+
+export default SystemMenu;

--- a/src/pages_back/userInfo/userInfo.tsx
+++ b/src/pages_back/userInfo/userInfo.tsx
@@ -1,8 +1,191 @@
-import React from 'react'
+import React, { useRef, useState } from 'react';
+import type { ColumnsType, ColumnType } from 'antd/es/table';
+import { DeleteTwoTone, EditTwoTone } from '@ant-design/icons';
+import { SearchOutlined } from '@ant-design/icons';
+import type { InputRef } from 'antd';
+import { Button, Input, Space, Table } from 'antd';
+import type { FilterConfirmProps } from 'antd/es/table/interface';
+import Highlighter from 'react-highlight-words';
 
-const UserInfo = () => {
-  return(
-    <h1>Userinfo</h1>
-  )
+//定义数据属性
+interface DataType {
+  key: string;
+  user_name: string;
+  character: string;
+  class: number;
+  email: string;
 }
+
+type DataIndex = keyof DataType;
+
+const data: DataType[] = [
+  {
+    key: '1',
+    user_name: '张三',
+    character: '管理员',
+    class: 1,
+    email: '123456@qq.com',
+  },
+  {
+    key: '2',
+    user_name: '李四',
+    character: '学生',
+    class: 2,
+    email: '11111@163.com',
+  },
+  {
+    key: '3',
+    user_name: '王五',
+    character: '学生',
+    class: 3,
+    email: 'abcde@gmail.com',
+  },
+];
+
+
+const UserInfo: React.FC = () => {
+  const [searchText, setSearchText] = useState('');
+  const [searchedColumn, setSearchedColumn] = useState('');
+  // 搜索输入框
+  const searchInput = useRef<InputRef>(null);
+
+  //处理搜索的函数
+  const handleSearch = (
+    selectedKeys: string[],
+    confirm: (param?: FilterConfirmProps) => void,
+    dataIndex: DataIndex,
+  ) => {
+    confirm();
+    setSearchText(selectedKeys[0]);
+    setSearchedColumn(dataIndex);
+  };
+
+  //重置
+  const handleReset = (clearFilters: () => void) => {
+    clearFilters();
+    setSearchText('');
+  };
+
+  //获取列
+  const getColumnSearchProps = (dataIndex: DataIndex): ColumnType<DataType> => ({
+    filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters, close }) => (
+      <div style={{ padding: 8 }} onKeyDown={(e) => e.stopPropagation()}>
+        <Input
+          ref={searchInput}
+          placeholder={`Search ${dataIndex}`}
+          value={selectedKeys[0]}
+          onChange={(e) => setSelectedKeys(e.target.value ? [e.target.value] : [])}
+          onPressEnter={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
+          style={{ marginBottom: 8, display: 'block' }}
+        />
+        <Space>
+          <Button
+            type="primary"
+            onClick={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
+            icon={<SearchOutlined />}
+            size="small"
+            style={{ width: 90 }}
+          >
+            Search
+          </Button>
+          <Button
+            onClick={() => clearFilters && handleReset(clearFilters)}
+            size="small"
+            style={{ width: 90 }}
+          >
+            Reset
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            onClick={() => {
+              confirm({ closeDropdown: false });
+              setSearchText((selectedKeys as string[])[0]);
+              setSearchedColumn(dataIndex);
+            }}
+          >
+            Filter
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            onClick={() => {
+              close();
+            }}
+          >
+            close
+          </Button>
+        </Space>
+      </div>
+    ),
+    filterIcon: (filtered: boolean) => (
+      <SearchOutlined style={{ color: filtered ? '#1890ff' : undefined }} />
+    ),
+    onFilter: (value, record) =>
+      record[dataIndex]
+        .toString()
+        .toLowerCase()
+        .includes((value as string).toLowerCase()),
+    onFilterDropdownOpenChange: (visible) => {
+      if (visible) {
+        setTimeout(() => searchInput.current?.select(), 100);
+      }
+    },
+    //渲染搜索框页面
+    render: (text) =>
+      searchedColumn === dataIndex ? (
+        <Highlighter
+          highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
+          searchWords={[searchText]}
+          autoEscape
+          textToHighlight={text ? text.toString() : ''}
+        />
+      ) : (
+        text
+      ),
+  });
+
+  // 定义列
+  const columns: ColumnsType<DataType> = [
+    {
+      title: '用户名',
+      dataIndex: 'user_name',
+      key: 'user_name',
+      // width: '30%',
+      // 该列添加搜索功能
+      ...getColumnSearchProps('user_name'),
+      // render: (text) => <a>{text}</a>,
+    },
+    {
+      title: '邮箱',
+      dataIndex: 'email',
+      key: 'email',
+      ...getColumnSearchProps('email'),
+    },
+    {
+      title: '班级',
+      dataIndex: 'class',
+      key: 'class',
+    },
+    {
+      title: '角色',
+      dataIndex: 'character',
+      key: 'character',
+    },
+
+    {
+      title: '操作',
+      key: 'action',
+      render: (_, record) => (
+        <Space size="middle">
+          <EditTwoTone />
+          <DeleteTwoTone />
+        </Space>
+      ),
+    },
+  ];
+
+  return <Table columns={columns} dataSource={data} />;
+};
+
 export default UserInfo;


### PR DESCRIPTION
### Done
- 创建了后台管理系统的初始页面（点击User-ManageSystem即可跳转，在App.js和Navbar.tsx配好）
- 基础的侧边菜单栏目，主页是病例管理（/systemManage）
- 创建userInfo&caseManage等界面
### Todo:
- [ ] 导航菜单的路由配置和跳转到对应页面
- [ ] 调整ui样式